### PR TITLE
feat: Allow non-mac and granular ctrl

### DIFF
--- a/prefSetter.py
+++ b/prefSetter.py
@@ -36,6 +36,10 @@ prefs = {
                         'Cache-Control': '86400',
                     },
                 },
+                'default_class': 'REDUCED_REDUNDANCY',
+                'default_age': 86400,
+                'catalogs_age': 120,
+                'manifests_age': 120,
             }
          }
 


### PR DESCRIPTION
Add non-macos support specifically tested to work
in AWS lambda. Some of the values are hard-coded.

Add Granular control over cache and
storage class. Use `TYPE_age` in the preferences
to set a specific cache age.
IE - catalogs_age = 120
to set the age of all catalogs to 120 seconds.

Storage is the same with `TYPE_class`
IE - catalogs_class = STANDARD
to set the storage class of all catalogs to 120 seconds.

Fix #4
Fix #5